### PR TITLE
[BUILD] Add publish workflow with GitVersion

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,3 +14,6 @@
 
 ## Motivation
 <!-- Why were these changes made -->
+
+## Screenshots/Test Results
+<!-- If you have something nice to show -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+<!-- Choose one of the following PR title prefixes:
+[BREAKING] - breaking changes (major release)
+[NEW] - new functionality (minor release)
+[FIX] - bug fix
+[DOCS] - docs change
+[BUILD] - build system change
+[PERF] - performance improvement (should include benchmarks)
+[WORK] - generic changes
+[SKIP] - no changes to the source files, no version changes
+-->
+
+## Changes
+<!-- Describe in general what this PR changes -->
+
+## Motivation
+<!-- Why were these changes made -->

--- a/.github/workflows/dotnet-build-test.yml
+++ b/.github/workflows/dotnet-build-test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    name: build
+
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/dotnet-build-test.yml
+++ b/.github/workflows/dotnet-build-test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-
+    name: build
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -36,6 +36,8 @@ jobs:
       run: |
         dotnet publish \
         --os linux --arch x64 -c Release \
+        --self-contained true \
+        -p:PublishTrimmed=true \
         -p:PublishProfile=DefaultContainer \
         -p:Version=${{ steps.version.outputs.assemblySemVer }} \
         -p:InformationalVersion=${{ steps.version.outputs.semVer }} \
@@ -44,7 +46,6 @@ jobs:
 
     - name: Container publish
       env:
-        VERSION: ${{ steps.version.outputs.semVer }}
         SSH_KEY: ${{ secrets.SSH_PASSWORD }}
       run: |
         echo "$SSH_KEY" > privkey
@@ -52,12 +53,14 @@ jobs:
         # disable ssh host verification
         mkdir ~/.ssh
         echo -e "Host ${{ secrets.SSH_HOST }}\n  StrictHostKeyChecking no\n  UserKnownHostsFile=/dev/null" > ~/.ssh/config
+        # show image size
+        docker image ls excos
         echo "(1) Uploading container image..."
-        docker save excos:$VERSION | gzip | ssh -i privkey ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "sudo /usr/bin/docker load"
+        docker save excos:${{ steps.version.outputs.semVer }} | gzip | ssh -i privkey ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "sudo /usr/bin/docker load"
         echo "(2) Uploading docker-compose file..."
         scp -i privkey docker/test-server/docker-compose.yml ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:~/staging
         echo "(3) Running containers..."
-        ssh -i privkey ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "cd staging; VERSION=$VERSION sudo /usr/bin/docker-compose-up"
+        ssh -i privkey ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "cd staging; VERSION=${{ steps.version.outputs.semVer }} sudo /usr/bin/docker-compose-up"
         echo "(4) Cleaning up old images..."
         ssh -i privkey ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "sudo /usr/bin/docker-rmi-old excos"
 

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -20,7 +20,7 @@ jobs:
       uses: lewagon/wait-on-check-action@v1.3.4
       with:
         ref: ${{ github.ref }}
-        check-name: build
+        check-regexp: .*build.*
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         wait-interval: 10
   publish:

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -52,12 +52,12 @@ jobs:
         # disable ssh host verification
         mkdir ~/.ssh
         echo -e "Host ${{ secrets.SSH_HOST }}\n  StrictHostKeyChecking no\n  UserKnownHostsFile=/dev/null" > ~/.ssh/config
-        # copy image onto the test server
+        echo "(1) Uploading container image..."
         docker save excos:$VERSION | gzip | ssh -i privkey ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "sudo /usr/bin/docker load"
-        # upload docker-compose file
-        scp -i privkey docker/test-server/docker-compose.yml ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:/staging
-        # run containers
+        echo "(2) Uploading docker-compose file..."
+        scp -i privkey docker/test-server/docker-compose.yml ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:~/staging
+        echo "(3) Running containers..."
         ssh -i privkey ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "cd staging; VERSION=$VERSION sudo /usr/bin/docker-compose-up"
-        # clean up
+        echo "(4) Cleaning up old images..."
         ssh -i privkey ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "sudo /usr/bin/docker-rmi-old excos"
 

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -48,6 +48,9 @@ jobs:
         SSH_KEY: ${{ secrets.SSH_PASSWORD }}
       run: |
         echo "$SSH_KEY" > privkey
+        # disable ssh host verification
+        mkdir ~/.ssh
+        echo -e "Host ${{ secrets.SSH_HOST }}\n  StrictHostKeyChecking no\n  UserKnownHostsFile=/dev/null" > ~/.ssh/config
         # copy image onto the test server
         docker save excos:$VERSION | gzip | ssh -i privkey ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "sudo /usr/bin/docker load"
         # upload docker-compose file

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Container publish
       env:
-      - VERSION: ${{ steps.version.outputs.semVer }}
+        VERSION: ${{ steps.version.outputs.semVer }}
       run: |
         echo ${{ secrets.SSH_PASSWORD }} > privkey
         # copy image onto the test server

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -48,6 +48,7 @@ jobs:
         SSH_KEY: ${{ secrets.SSH_PASSWORD }}
       run: |
         echo "$SSH_KEY" > privkey
+        chmod 400 privkey # required by SSH
         # disable ssh host verification
         mkdir ~/.ssh
         echo -e "Host ${{ secrets.SSH_HOST }}\n  StrictHostKeyChecking no\n  UserKnownHostsFile=/dev/null" > ~/.ssh/config

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches: [ "main" ]
   workflow_dispatch: # allow running by manual trigger
-  #TODO: remove below
-  pull_request:
-    branches: [ "main" ]
 
 concurrency:
   group: publish

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -46,7 +46,7 @@ jobs:
       env:
         VERSION: ${{ steps.version.outputs.semVer }}
       run: |
-        echo ${{ secrets.SSH_PASSWORD }} > privkey
+        echo "${{ secrets.SSH_PASSWORD }}" > privkey
         # copy image onto the test server
         docker save excos:$VERSION | gzip | ssh -i privkey ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "sudo /usr/bin/docker load"
         # upload docker-compose file

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -1,0 +1,41 @@
+name: Publish .NET Service
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch: # allow running by manual trigger
+  #TODO: remove below
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  publish:
+    name: Publish service
+    runs-on: ubuntu-latest
+    environment: test
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # full checkout
+    - name: Install GitVersion
+      uses: gittools/actions/gitversion/setup@v3.0.0
+    - name: Determine Version
+      id: version # step id used as reference for output values
+      uses: gittools/actions/gitversion/execute@v3.0.0
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+    - name: Install .NET Aspire workload
+      run: dotnet workload install aspire
+    
+    - name: .NET Publish
+      run: |
+        dotnet publish \
+        --os linux --arch x64 -c Release \
+        -p:PublishProfile=DefaultContainer \
+        -p:Version=${{ steps.version.outputs.assemblySemVer }} \
+        -p:InformationalVersion=${{ steps.version.outputs.semVer }} \
+        -p:ShortSha=${{ steps.version.outputs.shortSha }}
+      working-directory: src/Excos.Platform.WebApiHost
+

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -52,7 +52,7 @@ jobs:
         chmod 400 privkey # required by SSH
         # disable ssh host verification
         mkdir ~/.ssh
-        echo -e "Host ${{ secrets.SSH_HOST }}\n  StrictHostKeyChecking no\n  UserKnownHostsFile=/dev/null" > ~/.ssh/config
+        echo -e "Host ${{ secrets.SSH_HOST }}\n  StrictHostKeyChecking no" > ~/.ssh/config
         # show image size
         docker image ls excos
         echo "(1) Uploading container image..."

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -60,7 +60,7 @@ jobs:
         echo "(2) Uploading docker-compose file..."
         scp -i privkey docker/test-server/docker-compose.yml ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:~/staging
         echo "(3) Running containers..."
-        ssh -i privkey ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "cd staging; VERSION=${{ steps.version.outputs.semVer }} sudo /usr/bin/docker-compose-up"
+        ssh -i privkey ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "cd staging; export VERSION=${{ steps.version.outputs.semVer }}; sudo -E /usr/bin/docker-compose-up"
         echo "(4) Cleaning up old images..."
         ssh -i privkey ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "sudo /usr/bin/docker-rmi-old excos"
 

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Wait for build to complete
-      uses: lewagon/wait-on-check-action@v.1.3.4
+      uses: lewagon/wait-on-check-action@v1.3.4
       with:
         ref: ${{ github.ref }}
         check-name: build

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -8,11 +8,26 @@ on:
   pull_request:
     branches: [ "main" ]
 
+concurrency:
+  group: publish
+
 jobs:
+  wait:
+    name: Wait on build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Wait for build to complete
+      uses: lewagon/wait-on-check-action@v.1.3.4
+      with:
+        ref: ${{ github.ref }}
+        check-name: build
+        repo-token: ${{ secret.GITHUB_TOKEN }}
+        wait-interval: 10
   publish:
     name: Publish service
     runs-on: ubuntu-latest
     environment: test
+    needs: [ wait ]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -45,8 +45,9 @@ jobs:
     - name: Container publish
       env:
         VERSION: ${{ steps.version.outputs.semVer }}
+        SSH_KEY: ${{ secrets.SSH_PASSWORD }}
       run: |
-        echo "${{ secrets.SSH_PASSWORD }}" > privkey
+        echo "$SSH_KEY" > privkey
         # copy image onto the test server
         docker save excos:$VERSION | gzip | ssh -i privkey ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "sudo /usr/bin/docker load"
         # upload docker-compose file

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         ref: ${{ github.ref }}
         check-name: build
-        repo-token: ${{ secret.GITHUB_TOKEN }}
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
         wait-interval: 10
   publish:
     name: Publish service

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -12,22 +12,10 @@ concurrency:
   group: publish
 
 jobs:
-  wait:
-    name: Wait on build
-    runs-on: ubuntu-latest
-    steps:
-    - name: Wait for build to complete
-      uses: lewagon/wait-on-check-action@v1.3.4
-      with:
-        ref: ${{ github.ref }}
-        check-regexp: .*build.*
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        wait-interval: 10
   publish:
     name: Publish service
     runs-on: ubuntu-latest
     environment: test
-    needs: [ wait ]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -53,4 +41,18 @@ jobs:
         -p:InformationalVersion=${{ steps.version.outputs.semVer }} \
         -p:ShortSha=${{ steps.version.outputs.shortSha }}
       working-directory: src/Excos.Platform.WebApiHost
+
+    - name: Container publish
+      env:
+      - VERSION: ${{ steps.version.outputs.semVer }}
+      run: |
+        echo ${{ secrets.SSH_PASSWORD }} > privkey
+        # copy image onto the test server
+        docker save excos:$VERSION | gzip | ssh -i privkey ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "sudo /usr/bin/docker load"
+        # upload docker-compose file
+        scp -i privkey docker/test-server/docker-compose.yml ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:/staging
+        # run containers
+        ssh -i privkey ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "cd staging; VERSION=$VERSION sudo /usr/bin/docker-compose-up"
+        # clean up
+        ssh -i privkey ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "sudo /usr/bin/docker-rmi-old excos"
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,12 @@
 <Project>
 	<PropertyGroup>
 		<NoWarn>$(NoWarn);ASPIRE001</NoWarn>
+
+		<!-- We want to set the following based on GitVersion output
+			/p Version=$(assemblySemVer)
+			/p InformationalVersion=$(semVer)
+			/p ShortSha=$(shortSha)
+		-->
+		<SourceRevisionId Condition="'$(ShortSha)' != ''">$(ShortSha)</SourceRevisionId>
 	</PropertyGroup>
 </Project>

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,5 @@
+workflow: TrunkBased/preview1
+major-version-bump-message: \[BREAKING\]
+minor-version-bump-message: \[NEW\]
+patch-version-bump-message: \[(FIX|DOCS|BUILD|PERF|WORK)\]
+no-bump-message: \[SKIP\]

--- a/docker/test-server/docker-compose.yml
+++ b/docker/test-server/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     networks: [ excos_inner ]
     environment:
       ASPNETCORE_ENVIRONMENT: Staging
+      ASPNETCORE_URLS: http://excos:80/
   proxy:
     image: steveltn/https-portal
     ports:

--- a/docker/test-server/docker-compose.yml
+++ b/docker/test-server/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  excos:
+    image: excos:${VERSION}
+    networks: [ excos_inner ]
+    environment:
+      ASPNETCORE_ENVIRONMENT: Staging
+  proxy:
+    image: steveltn/https-portal
+    ports:
+    - '80:80'
+    - '443:443'
+    links:
+    - excos
+    deploy:
+      restart_policy:
+        condition: any
+        delay: 60s
+    volumes:
+      - proxy-data:/var/lib/https-portal
+    healthcheck:
+      test: ["CMD", "service", "nginx", "status"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+    environment:
+      DOMAINS: 'test.excos.dev -> http://excos'
+      STAGE: 'production'
+      WEBSOCKET: 'true'
+      CLIENT_MAX_BODY_SIZE: '0'
+    networks: [ excos_inner ]
+
+volumes:
+  proxy-data:
+networks:
+  excos_inner:

--- a/src/Excos.Platform.WebApiHost/Excos.Platform.WebApiHost.csproj
+++ b/src/Excos.Platform.WebApiHost/Excos.Platform.WebApiHost.csproj
@@ -17,7 +17,7 @@
 	</ItemGroup>
 
 	<PropertyGroup>
-		<ContainerImageName>excos</ContainerImageName>
+		<ContainerRepository>excos</ContainerRepository>
 		<ContainerImageTags>latest;$(InformationalVersion)</ContainerImageTags>
 		<ContainerBaseImage>mcr.microsoft.com/dotnet/runtime-deps:8.0-noble-chiseled</ContainerBaseImage>
   	</PropertyGroup>

--- a/src/Excos.Platform.WebApiHost/Excos.Platform.WebApiHost.csproj
+++ b/src/Excos.Platform.WebApiHost/Excos.Platform.WebApiHost.csproj
@@ -16,4 +16,12 @@
 		<PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
 	</ItemGroup>
 
+	<PropertyGroup>
+		<ContainerImageName>excos</ContainerImageName>
+		<ContainerImageTags>latest;$(InformationalVersion)</ContainerImageTags>
+  	</PropertyGroup>
+  	<ItemGroup>
+    	<ContainerPort Include="80" Type="tcp" />
+  	</ItemGroup>
+
 </Project>

--- a/src/Excos.Platform.WebApiHost/Excos.Platform.WebApiHost.csproj
+++ b/src/Excos.Platform.WebApiHost/Excos.Platform.WebApiHost.csproj
@@ -19,6 +19,7 @@
 	<PropertyGroup>
 		<ContainerImageName>excos</ContainerImageName>
 		<ContainerImageTags>latest;$(InformationalVersion)</ContainerImageTags>
+		<ContainerBaseImage>mcr.microsoft.com/dotnet/runtime-deps:8.0-noble-chiseled</ContainerBaseImage>
   	</PropertyGroup>
   	<ItemGroup>
     	<ContainerPort Include="80" Type="tcp" />


### PR DESCRIPTION
## Changes
Adding a PR template so I don't forget about semver prefixes, [GitVersion](https://gitversion.net/) config, container setting for web project and a publish workflow which builds the container and deploys to test environment.

### Highlights
1. The .NET publish command uses `SelfContained` and `PublishTrimmed` which in conjunction with `<ContainerBaseImage>mcr.microsoft.com/dotnet/runtime-deps:8.0-noble-chiseled</ContainerBaseImage>` allow us to make a 45MB image, which is about 5x smaller than the default configuration.

## Motivation
1. The versioning part - as I work on Excos I want to make sure any telemetry I gather from running the system in the test environment is correctly tagged with a version - this will allow to track builds back to source AND to distinguish changes between versions later when I work on the experimentation part of the platform.
3. The publishing part - I want to be able to continuously test the service.

## Screenshots/Test Results
![image](https://github.com/user-attachments/assets/736e0bb9-d06c-4e76-934d-b603d91034cc)
