### PR TITLE
[SKIP] Add size labels to PRs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,33 @@
+name: Add PR size label
+
+on: 
+	pull_request_target:
+		types: [opened, synchronize, reopened]
+
+jobs:
+  labeler:
+    permissions:
+      pull-requests: write
+      contents: read
+      issues: write
+    runs-on: ubuntu-latest
+    name: Label the PR size
+    steps:
+      - uses: codelytv/pr-size-labeler@v1
+        with:
+          xs_label: 'size:XS'
+          xs_max_size: '25'
+          s_label: 'size:S'
+          s_max_size: '150'
+          m_label: 'size:M'
+          m_max_size: '500'
+          l_label: 'size:L'
+          l_max_size: '1200'
+          xl_label: 'size:XL'
+          fail_if_xl: 'false'
+          message_if_xl: >
+            This PR exceeds the recommended size of 1200 lines.
+            Please make sure you are NOT addressing multiple issues with one PR.
+            Note this PR might be rejected due to its size.
+          ignore_file_deletions: true
+	


### PR DESCRIPTION
## Changes
Adding a new workflow for adding PR size labels: https://github.com/marketplace/actions/pull-request-size-labeler

## Motivation
It's nice to be able to quickly see which PRs are larger/smaller

## Screenshots/Test Results
![image](https://github.com/user-attachments/assets/056edce9-34cc-4b9e-b823-f09885cd772e)