### PR TITLE
[BUILD] Add DEPS label for package updates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,7 @@
 [DOCS] - docs change
 [BUILD] - build system change
 [PERF] - performance improvement (should include benchmarks)
+[DEPS] - dependency update
 [WORK] - generic changes
 [SKIP] - no changes to the source files, no version changes
 -->

--- a/.github/workflows/dotnet-package-update.yaml
+++ b/.github/workflows/dotnet-package-update.yaml
@@ -41,6 +41,6 @@ jobs:
         git add -u
         git commit -m ".NET Package update"
         git push -u origin "package-update/dotnet/run$GITHUB_RUN_NUMBER"
-        gh pr create -B main -H "package-update/dotnet/run$GITHUB_RUN_NUMBER" --title ".NET Package Update ($(date +%D))" --body "$(cat upgrade.md)"
+        gh pr create -B main -H "package-update/dotnet/run$GITHUB_RUN_NUMBER" --title "[DEPS] .NET Package Update ($(date +%D))" --body "$(cat upgrade.md)"
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: Add PR size label
 
 on: 
-	pull_request_target:
+  pull_request_target:
 		types: [opened, synchronize, reopened]
 
 jobs:

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 workflow: TrunkBased/preview1
 major-version-bump-message: \[BREAKING\]
 minor-version-bump-message: \[NEW\]
-patch-version-bump-message: \[(FIX|DOCS|BUILD|PERF|WORK)\]
+patch-version-bump-message: \[(FIX|DOCS|BUILD|PERF|DEPS|WORK)\]
 no-bump-message: \[SKIP\]


### PR DESCRIPTION
## Changes
Adding a new `[DEPS]` label for PRs which are updating dependencies.
If dependency update changes public behavior, it should probably be deferred until a major release.

Also fixes whitespaces in #8 
