### PR TITLE
[WORK] Update format rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -30,10 +30,10 @@ dotnet_sort_system_directives_first = true
 file_header_template = Copyright (c) Marian Dziubiak.\nLicensed under the GNU Affero General Public License v3.
 
 # this. and Me. preferences
-dotnet_style_qualification_for_event = false:silent
-dotnet_style_qualification_for_field = false:silent
-dotnet_style_qualification_for_method = false:silent
-dotnet_style_qualification_for_property = false:silent
+dotnet_style_qualification_for_event = true:error
+dotnet_style_qualification_for_field = true:error
+dotnet_style_qualification_for_method = true:error
+dotnet_style_qualification_for_property = true:error
 
 # Language keywords vs BCL types preferences
 dotnet_style_predefined_type_for_locals_parameters_members = true:silent
@@ -46,7 +46,7 @@ dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
 dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
 
 # Modifier preferences
-dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
 
 # Expression-level preferences
 dotnet_style_coalesce_expression = true:suggestion
@@ -122,7 +122,7 @@ csharp_style_unused_value_assignment_preference = discard_variable:suggestion
 csharp_style_unused_value_expression_statement_preference = discard_variable:silent
 
 # 'using' directive preferences
-csharp_using_directive_placement = outside_namespace:silent
+csharp_using_directive_placement = outside_namespace:suggestion
 
 #### C# Formatting Rules ####
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -22,12 +22,12 @@ end_of_line = crlf
 insert_final_newline = false
 
 #### .NET Coding Conventions ####
-[*.{cs,vb}]
+[*.{cs,vb,fs}]
 
 # Organize usings
-dotnet_separate_import_directive_groups = true
+dotnet_separate_import_directive_groups = false
 dotnet_sort_system_directives_first = true
-file_header_template = unset
+file_header_template = Copyright (c) Marian Dziubiak.\nLicensed under the GNU Affero General Public License v3.
 
 # this. and Me. preferences
 dotnet_style_qualification_for_event = false:silent
@@ -78,9 +78,9 @@ dotnet_remove_unnecessary_suppression_exclusions = none
 [*.cs]
 
 # var preferences
-csharp_style_var_elsewhere = false:silent
-csharp_style_var_for_built_in_types = false:silent
-csharp_style_var_when_type_is_apparent = false:silent
+csharp_style_var_elsewhere = false:warning
+csharp_style_var_for_built_in_types = false:warning
+csharp_style_var_when_type_is_apparent = true:warning
 
 # Expression-bodied members
 csharp_style_expression_bodied_accessors = true:silent
@@ -218,11 +218,11 @@ dotnet_naming_rule.public_fields_should_be_pascalcase.style = pascalcase
 
 dotnet_naming_rule.private_fields_should_be__camelcase.severity = suggestion
 dotnet_naming_rule.private_fields_should_be__camelcase.symbols = private_fields
-dotnet_naming_rule.private_fields_should_be__camelcase.style = _camelcase
+dotnet_naming_rule.private_fields_should_be__camelcase.style = camelcase
 
 dotnet_naming_rule.private_static_fields_should_be_s_camelcase.severity = suggestion
 dotnet_naming_rule.private_static_fields_should_be_s_camelcase.symbols = private_static_fields
-dotnet_naming_rule.private_static_fields_should_be_s_camelcase.style = s_camelcase
+dotnet_naming_rule.private_static_fields_should_be_s_camelcase.style = camelcase
 
 dotnet_naming_rule.public_constant_fields_should_be_pascalcase.severity = suggestion
 dotnet_naming_rule.public_constant_fields_should_be_pascalcase.symbols = public_constant_fields

--- a/.github/workflows/dotnet-format.yaml
+++ b/.github/workflows/dotnet-format.yaml
@@ -28,6 +28,7 @@ jobs:
         git diff -s --exit-code && exit 0
         git config --global user.email "bot@excos.dev"
         git config --global user.name "Excos Bot"
+        git config --global core.autocrlf input
         git add -u
         git commit -m ".NET Format"
         git push

--- a/.github/workflows/dotnet-format.yaml
+++ b/.github/workflows/dotnet-format.yaml
@@ -1,0 +1,34 @@
+name: .NET Format
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  check-for-updates:
+    name: Format
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # full checkout
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+    - name: Install .NET Aspire workload
+      run: dotnet workload install aspire
+    
+    - name: Run dotnet format
+      run: dotnet format
+    - name: Add updated files to Git
+      run: |
+        git diff -s --exit-code && exit 0
+        git config --global user.email "bot@excos.dev"
+        git config --global user.name "Excos Bot"
+        git add -u
+        git commit -m ".NET Format"
+        git push
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dotnet-format.yaml
+++ b/.github/workflows/dotnet-format.yaml
@@ -29,4 +29,6 @@ jobs:
     # to trigger build.
     # see https://github.com/orgs/community/discussions/25702
     - name: Check if there's any changes
-      run: git diff -s --exit-code
+      run: |
+        git config --global core.autocrlf input
+        git diff -s --exit-code

--- a/.github/workflows/dotnet-format.yaml
+++ b/.github/workflows/dotnet-format.yaml
@@ -24,6 +24,7 @@ jobs:
       run: dotnet format
     - name: Add updated files to Git
       run: |
+        git checkout ${{ github.head_ref }}
         git diff -s --exit-code && exit 0
         git config --global user.email "bot@excos.dev"
         git config --global user.name "Excos Bot"

--- a/.github/workflows/dotnet-format.yaml
+++ b/.github/workflows/dotnet-format.yaml
@@ -22,15 +22,11 @@ jobs:
     
     - name: Run dotnet format
       run: dotnet format
-    - name: Add updated files to Git
-      run: |
-        git checkout ${{ github.head_ref }}
-        git diff -s --exit-code && exit 0
-        git config --global user.email "bot@excos.dev"
-        git config --global user.name "Excos Bot"
-        git config --global core.autocrlf input
-        git add -u
-        git commit -m ".NET Format"
-        git push
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # initially this workflow was going to push formatted changes
+    # to the PR branch (saving my time), but GitHub doesn't allow
+    # running workflows on top of commit pushed using GITHUB_TOKEN
+    # which means after a format I would anyways have to push an empty commit
+    # to trigger build.
+    # see https://github.com/orgs/community/discussions/25702
+    - name: Check if there's any changes
+      run: git diff -s --exit-code

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,6 +15,8 @@ jobs:
       SHELLOPTS: xtrace
     steps:
       - uses: codelytv/pr-size-labeler@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           xs_label: 'size:XS'
           xs_max_size: '25'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,9 +15,8 @@ jobs:
       SHELLOPTS: xtrace
     steps:
       - uses: codelytv/pr-size-labeler@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           xs_label: 'size:XS'
           xs_max_size: '25'
           s_label: 'size:S'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,8 +1,7 @@
 name: Add PR size label
 
 on: 
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+  pull_request:
 
 jobs:
   labeler:
@@ -30,3 +29,5 @@ jobs:
             Please make sure you are NOT addressing multiple issues with one PR.
             Note this PR might be rejected due to its size.
           ignore_file_deletions: true
+        env:
+          BASHOPTS: xtrace

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,6 +11,8 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     name: Label the PR size
+    env:
+      SHELLOPTS: xtrace
     steps:
       - uses: codelytv/pr-size-labeler@v1
         with:
@@ -29,5 +31,3 @@ jobs:
             Please make sure you are NOT addressing multiple issues with one PR.
             Note this PR might be rejected due to its size.
           ignore_file_deletions: true
-        env:
-          BASHOPTS: xtrace

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,8 @@
 name: Add PR size label
 
 on: 
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 jobs:
   labeler:
@@ -11,8 +12,8 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     name: Label the PR size
-    env:
-      SHELLOPTS: xtrace
+    #env:
+    #  SHELLOPTS: xtrace # debug action
     steps:
       - uses: codelytv/pr-size-labeler@v1
         with:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,6 @@
 	<PropertyGroup>
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
-
 	<ItemGroup Label="Host">
 		<PackageVersion Include="Aspire.Hosting.AppHost" Version="8.2.2" />
 		<PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
@@ -13,7 +12,6 @@
 		<PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
 		<PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
 	</ItemGroup>
-
 	<ItemGroup Label="Testing">
 		<PackageVersion Include="Aspire.Hosting.Testing" Version="8.2.2" />
 		<PackageVersion Include="coverlet.collector" Version="6.0.2" />

--- a/src/Excos.Platform.AppHost/Program.cs
+++ b/src/Excos.Platform.AppHost/Program.cs
@@ -1,6 +1,9 @@
+// Copyright (c) Marian Dziubiak.
+// Licensed under the GNU Affero General Public License v3.
+
 using Projects;
 
-var builder = DistributedApplication.CreateBuilder(args);
+IDistributedApplicationBuilder builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddProject<Excos_Platform_WebApiHost>("WebApiHost");
 

--- a/src/Excos.Platform.AppHost/Program.cs
+++ b/src/Excos.Platform.AppHost/Program.cs
@@ -3,7 +3,7 @@
 
 using Projects;
 
-var builder = DistributedApplication.CreateBuilder(args);
+IDistributedApplicationBuilder builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddProject<Excos_Platform_WebApiHost>("WebApiHost");
 

--- a/src/Excos.Platform.AppHost/Program.cs
+++ b/src/Excos.Platform.AppHost/Program.cs
@@ -3,7 +3,7 @@
 
 using Projects;
 
-IDistributedApplicationBuilder builder = DistributedApplication.CreateBuilder(args);
+var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddProject<Excos_Platform_WebApiHost>("WebApiHost");
 

--- a/src/Excos.Platform.WebApiHost/Healthchecks/HealthCheckConfigurationExtensions.cs
+++ b/src/Excos.Platform.WebApiHost/Healthchecks/HealthCheckConfigurationExtensions.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+﻿// Copyright (c) Marian Dziubiak.
+// Licensed under the GNU Affero General Public License v3.
+
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Excos.Platform.WebApiHost.Healthchecks;

--- a/src/Excos.Platform.WebApiHost/Program.cs
+++ b/src/Excos.Platform.WebApiHost/Program.cs
@@ -1,7 +1,10 @@
+// Copyright (c) Marian Dziubiak.
+// Licensed under the GNU Affero General Public License v3.
+
 using Excos.Platform.WebApiHost.Healthchecks;
 using Excos.Platform.WebApiHost.Telemetry;
 
-var builder = WebApplication.CreateBuilder(args);
+WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 builder.ConfigureOpenTelemetry();
 
@@ -18,7 +21,7 @@ builder.Services.ConfigureHttpClientDefaults(http =>
 	http.AddServiceDiscovery();
 });
 
-var app = builder.Build();
+WebApplication app = builder.Build();
 
 app.MapGet("/", () => "Hello World!");
 app.MapDevHealthCheckEndpoints();

--- a/src/Excos.Platform.WebApiHost/Telemetry/TelemetryConfigurationExtensions.cs
+++ b/src/Excos.Platform.WebApiHost/Telemetry/TelemetryConfigurationExtensions.cs
@@ -1,4 +1,7 @@
-﻿using OpenTelemetry;
+﻿// Copyright (c) Marian Dziubiak.
+// Licensed under the GNU Affero General Public License v3.
+
+using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 
@@ -36,7 +39,7 @@ public static class TelemetryConfigurationExtensions
 
 	private static IHostApplicationBuilder AddOpenTelemetryExporters(this IHostApplicationBuilder builder)
 	{
-		var useOtlpExporter = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
+		bool useOtlpExporter = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
 
 		if (useOtlpExporter)
 		{

--- a/test/Excos.Platform.AppHostTests/AppHost.cs
+++ b/test/Excos.Platform.AppHostTests/AppHost.cs
@@ -1,17 +1,20 @@
-﻿namespace Excos.Platform.AppHostTests;
+﻿// Copyright (c) Marian Dziubiak.
+// Licensed under the GNU Affero General Public License v3.
+
+namespace Excos.Platform.AppHostTests;
 
 public static class AppHost
 {
 	public static async Task<DistributedApplication> StartAsync()
 	{
-		var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.Excos_Platform_AppHost>();
+		IDistributedApplicationTestingBuilder appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.Excos_Platform_AppHost>();
 		appHost.Services.ConfigureHttpClientDefaults(clientBuilder =>
 		{
 			clientBuilder.AddStandardResilienceHandler();
 		});
 		// To output logs to the xUnit.net ITestOutputHelper, consider adding a package from https://www.nuget.org/packages?q=xunit+logging
 
-		var app = await appHost.BuildAsync();
+		DistributedApplication app = await appHost.BuildAsync();
 		await app.StartAsync();
 
 		return app;
@@ -19,10 +22,10 @@ public static class AppHost
 
 	public static async Task<HttpClient> GetWebApiClientAsync(this DistributedApplication app)
 	{
-		var resourceNotificationService = app.Services.GetRequiredService<ResourceNotificationService>();
+		ResourceNotificationService resourceNotificationService = app.Services.GetRequiredService<ResourceNotificationService>();
 		await resourceNotificationService.WaitForResourceAsync("WebApiHost", KnownResourceStates.Running).WaitAsync(TimeSpan.FromSeconds(30));
 
-		var httpClient = app.CreateHttpClient("WebApiHost");
+		HttpClient httpClient = app.CreateHttpClient("WebApiHost");
 		return httpClient;
 	}
 }

--- a/test/Excos.Platform.AppHostTests/ServiceLivenessTests.cs
+++ b/test/Excos.Platform.AppHostTests/ServiceLivenessTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Marian Dziubiak.
+// Licensed under the GNU Affero General Public License v3.
+
 namespace Excos.Platform.AppHostTests.Tests;
 
 public class ServiceLivenessTests
@@ -6,11 +9,11 @@ public class ServiceLivenessTests
 	public async Task GetWebResourceRootReturnsOkStatusCode()
 	{
 		// Arrange
-		await using var app = await AppHost.StartAsync();
+		await using DistributedApplication app = await AppHost.StartAsync();
 
 		// Act
-		var httpClient = await app.GetWebApiClientAsync();
-		var response = await httpClient.GetAsync("/alive");
+		HttpClient httpClient = await app.GetWebApiClientAsync();
+		HttpResponseMessage response = await httpClient.GetAsync("/alive");
 
 		// Assert
 		Assert.Equal(HttpStatusCode.OK, response.StatusCode);


### PR DESCRIPTION
## Changes
Adding a new workflow which will fail if the PR is not formatted correctly.

* Adding copyright header to files
* Not separating usings in .NET files
* Enforcing `this` usage with members (and dropping _ prefix for private members)
* Changing the style of `var` usage in C#
* Changing the style of private fields in .NET naming rules

## Motivation
I want to ensure the code in the repo is formatted consistently.
My preferred style rules, which I thought were applied during bootstrap, but apparently Visual Studio didn't persist them, so adding them again.
