### PR TITLE
[BUILD] In update pipeline always try to write summary

### DIFF
--- a/.github/workflows/dotnet-package-update.yaml
+++ b/.github/workflows/dotnet-package-update.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dotnet-outdated
       run: dotnet tool install --global dotnet-outdated-tool
     - name: Run dotnet-outdated
-      run: dotnet outdated --upgrade -o upgrade.md -of Markdown
+      run: dotnet outdated --no-restore --upgrade -o upgrade.md -of Markdown
     - name: Output to summary
       if: always() # run even if the previous step fails
       run: |

--- a/.github/workflows/dotnet-package-update.yaml
+++ b/.github/workflows/dotnet-package-update.yaml
@@ -26,6 +26,7 @@ jobs:
     - name: Run dotnet-outdated
       run: dotnet outdated --upgrade -o upgrade.md -of Markdown
     - name: Output to summary
+      if: always() # run even if the previous step fails
       run: |
         if test -f upgrade.md; then
           cat upgrade.md >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Changes
The package update pipeline can fail if there's an issue with one of the packages. ~~I believe there's some logging into the generated MD file~~ It's good to have the md output even if it doesn't bring any new info on failure, so we need to consume it in the next step instead of cancelling the pipeline.

The actual approach to mitigate those issues is to disable the restore in the pipeline. Instead it will create the PR and then we will observe the failure on the PR build (if it exists at that point). I suspect the issue is that restoring projects after each package change can fail while restoring them all at once after updates would succeed in many cases.