### PR TITLE
[BUILD] Add OpenTelemetry params for test deployment

### DIFF
--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -59,7 +59,7 @@ jobs:
         echo "(2) Uploading docker-compose file..."
         scp -i privkey docker/test-server/docker-compose.yml ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:~/staging
         echo "(3) Running containers..."
-        ssh -i privkey ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "cd staging; export VERSION=${{ steps.version.outputs.semVer }}; sudo -E /usr/bin/docker-compose-up"
+        ssh -i privkey ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "cd staging; export VERSION=${{ steps.version.outputs.semVer }} OTLP_PROTOCOL=${{ vars.OTLP_PROTOCOL }} OTLP_ENDPOINT=${{ vars.OTLP_ENDPOINT }} OTLP_HEADERS=${{ secrets.OTLP_HEADERS }}; sudo -E /usr/bin/docker-compose-up"
         echo "(4) Cleaning up old images..."
         ssh -i privkey ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "sudo /usr/bin/docker-rmi-old excos"
 

--- a/docker/test-server/docker-compose.yml
+++ b/docker/test-server/docker-compose.yml
@@ -6,6 +6,10 @@ services:
       ASPNETCORE_ENVIRONMENT: Staging
       ASPNETCORE_URLS: http://excos:80/
       ConnectionStrings__postgres: "Host=postgres;Port=5432;Database=excos;Username=docker;Password=docker"
+      OTEL_SERVICE_NAME: excos-web
+      OTEL_EXPORTER_OTLP_PROTOCOL: ${OTLP_PROTOCOL}
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTLP_ENDPOINT}
+      OTEL_EXPORTER_OTLP_HEADERS: ${OTLP_HEADERS}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Changes
OTEL in .NET supports configuration through env variables to point at a collector. I'm exposing those variables in the docker-compose file and setting them during deployment in GitHub Action.

## Motivation
I want to be able to see the telemetry emitted by the server in the test deployment. The GitHub repo is set up with details of my Honeycomb account.

## Screenshots/Test Results
![image](https://github.com/user-attachments/assets/4d92ba5c-c5f2-4a7d-8b1d-afcb0cb7e926)